### PR TITLE
Play opening cutscene immediately to capture correct player pos

### DIFF
--- a/mods/artifact_characters/init.lua
+++ b/mods/artifact_characters/init.lua
@@ -188,7 +188,7 @@ minetest.register_on_joinplayer(function(p)
     end
     if artifact.story.state < artifact.story.state_start then
         p:set_pos(artifact.poi.region1)
-        minetest.after(0, artifact.cutscene_start)
+        artifact.cutscene_start()
     end
     if not artifact.debug then
         p:set_inventory_formspec("")


### PR DESCRIPTION
There is some engine behavior that affects certain user setups where upon initial mapblock loading, after calling `player:set_pos()` the server steps immediately afterwards have an old player position (due to client updates), causing the saved cutscene position (captured a step afterward) to be incorrect (and spawns the player in the void). This removes the `minetest.after` so the captured position is in the same sever step (and thus correct).

This is an acceptable fix during the jam so that the game is at least playable.